### PR TITLE
Skip attaching handler to passed (options.skip) tab indices

### DIFF
--- a/js/cbpFWTabs.js
+++ b/js/cbpFWTabs.js
@@ -29,7 +29,8 @@
 	}
 
 	CBPFWTabs.prototype.options = {
-		start : 0
+		start : 0,
+		skip : []
 	};
 
 	CBPFWTabs.prototype._init = function() {
@@ -47,12 +48,15 @@
 
 	CBPFWTabs.prototype._initEvents = function() {
 		var self = this;
-		this.tabs.forEach( function( tab, idx ) {
-			tab.addEventListener( 'click', function( ev ) {
-				ev.preventDefault();
-				self._show( idx );
-			} );
-		} );
+		var skip = this.options.skip;
+        this.tabs.forEach( function( tab, idx ) {
+            if (skip.indexOf(idx) == -1) {
+                tab.addEventListener( 'click', function( ev ) {
+                    ev.preventDefault();
+                    self._show( idx );
+                } );
+            }
+        } );
 	};
 
 	CBPFWTabs.prototype._show = function( idx ) {


### PR DESCRIPTION
Skips attaching event handler to specified tabs.

Uses include: external links, custom actions such as modals, etc.

Example usage:

`new CBPFWTabs( document.getElementById( 'tabs' ), {'skip' : [2, 3]} );`

**NB**: Array.indexOf is compatible with IE9 and above see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf).
