### PR TITLE
All nav descendants of passed element assigned click event

### DIFF
--- a/js/cbpFWTabs.js
+++ b/js/cbpFWTabs.js
@@ -29,13 +29,14 @@
 	}
 
 	CBPFWTabs.prototype.options = {
+		nav : 'nav',
 		start : 0,
 		skip : []
 	};
 
 	CBPFWTabs.prototype._init = function() {
 		// tabs elemes
-		this.tabs = [].slice.call( this.el.querySelectorAll( 'nav > ul > li' ) );
+		this.tabs = [].slice.call( this.el.querySelectorAll( this.options.nav + ' > ul > li' ) );
 		// content items
 		this.items = [].slice.call( this.el.querySelectorAll( '.content > section' ) );
 		// current index


### PR DESCRIPTION
Currently, all `nav` descendants of the passed element are also bound to the click event on init. This may include multiple `nav`s inside of tabs used for navigating a `section` or filtering content.

Proposed example usage:

`new CBPFWTabs( document.getElementById( 'tabs' ), {'nav' : '.nav-main'} );`

The default if no class or element is passed is `nav` as before, which grabs all the nav descendants, though it may perhaps be better to use a specific class (such as `.nav-main` in the example above) but this would require updating the HTML of the original article.
