### PR TITLE
Any existing classes overwritten when switching tabs

### DIFF
--- a/js/cbpFWTabs.js
+++ b/js/cbpFWTabs.js
@@ -62,13 +62,14 @@
 
 	CBPFWTabs.prototype._show = function( idx ) {
 		if( this.current >= 0 ) {
-			this.tabs[ this.current ].className = '';
-			this.items[ this.current ].className = '';
+			// remove and add class thanks to Apollo.js (github.com/toddmotto/apollo)
+            this.tabs[ this.current ].className = this.tabs[ this.current ].className.replace(new RegExp('(^|\\s)*' + 'tab-current' + '(\\s|$)*', 'g'), '');
+            this.items[ this.current ].className = this.items[ this.current ].className.replace(new RegExp('(^|\\s)*' + 'content-current' + '(\\s|$)*', 'g'), '');
 		}
 		// change current
 		this.current = idx != undefined ? idx : this.options.start >= 0 && this.options.start < this.items.length ? this.options.start : 0;
-		this.tabs[ this.current ].className = 'tab-current';
-		this.items[ this.current ].className = 'content-current';
+		this.tabs[ this.current ].className += (this.tabs[ this.current ].className ? ' ' : '') + 'tab-current';
+		this.items[ this.current ].className += (this.items[ this.current ].className ? ' ' : '') + 'content-current';
 	};
 
 	// add to global namespace


### PR DESCRIPTION
If you choose to have classes on either the nav elements, or any of the targeted sections, they are overwritten when the active classes are applied.

This update uses a bit of code from the [Apollo.js project](https://github.com/toddmotto/apollo) to remove and add classes dynamically.

If you see any obvious reasons why this may not function properly in any of the supported browsers, please let me know!
